### PR TITLE
Fixed backlog deletion bug on home page carousels

### DIFF
--- a/src/components/BacklogCarousel/BacklogCarousel.js
+++ b/src/components/BacklogCarousel/BacklogCarousel.js
@@ -4,22 +4,22 @@ import { useUser } from "../UserContext";
 import { getGameBacklog } from "../../utilities/Api/Backlog";
 
 function BacklogCarousel({ openModal }) {
-  const { user } = useUser();
+  const { user, backlog } = useUser();
   const [backlogData, setBacklogData] = useState([]);
 
   const getBacklogById = useCallback(async () => {
     try {
       let result = await getGameBacklog(user.id);
       setBacklogData(result.data);
-      console.log(result);
     } catch (error) {
       console.log(error);
     }
   }, [user.id]);
 
+  //When the backlog in the user context is updated by the boxart refetch the updated info
   useEffect(() => {
     getBacklogById();
-  }, [getBacklogById]);
+  }, [backlog]);
 
   return (
     <GenericCarousel

--- a/src/components/CollectionCarousel/CollectionCarousel.js
+++ b/src/components/CollectionCarousel/CollectionCarousel.js
@@ -4,8 +4,7 @@ import { useUser } from "../UserContext";
 import { getGameCollection } from "../../utilities/Api/Collection";
 
 function CollectionCarousel({ openModal }) {
-  // const { userCollection } = useUser();
-  const { user } = useUser();
+  const { user, userCollection } = useUser();
   const [collectionData, setCollectionData] = useState([]);
 
   const getCollectionById = useCallback(async () => {
@@ -17,9 +16,10 @@ function CollectionCarousel({ openModal }) {
     }
   }, [user.id]);
 
+  //When the collection in the user context is updated by the boxart refetch the updated info
   useEffect(() => {
     getCollectionById();
-  }, [getCollectionById]);
+  }, [userCollection]);
 
   return (
     <GenericCarousel

--- a/src/components/UserContext.js
+++ b/src/components/UserContext.js
@@ -77,7 +77,6 @@ export const UserProvider = ({ children }) => {
         try {
           const result = await getGameWishlist(user.id);
           setUserWishlist(result.data);
-          console.log(userWishlist)
         } catch (error) {
           console.error("Error fetching backlog data:", error);
         }

--- a/src/components/WishlistCarousel/WishlistCarousel.js
+++ b/src/components/WishlistCarousel/WishlistCarousel.js
@@ -4,10 +4,8 @@ import { useUser } from "../UserContext";
 import { getGameWishlist } from "../../utilities/Api/Wishlist";
 
 function WishlistCarousel({ openModal }) {
-  // const { userWishlist} = useUser();
-
-  const { user } = useUser();
-  const [userWishlist, setWishlist] = useState([]);
+  const { user, userWishlist } = useUser();
+  const [wishlistData, setWishlist] = useState([]);
 
   const getWishlistById = useCallback(async () => {
     try {
@@ -19,14 +17,15 @@ function WishlistCarousel({ openModal }) {
     }
   }, [user.id]);
 
+  //When the wishlist in the user context is updated by the boxart refetch the updated info
   useEffect(() => {
     getWishlistById();
-  }, [getWishlistById]);
+  }, [userWishlist]);
 
   return (
     <GenericCarousel
       label="Wishlist"
-      items={userWishlist}
+      items={wishlistData}
       openModal={openModal}
     />
   );


### PR DESCRIPTION
Made the carousels on the home page update dynamically by updating the user's lists in user context and fetching the updated data when a button on the box art is clicked.